### PR TITLE
refactor/fix: performance tweaks and cache location fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # horde-safety
+
 Provides safety features used by the horde, especially to do with image generation.
 
-## Note
+## Environment Variables
 
-This library is made with the default AI Horde worker in mind, and relies on the environment variable `AIWORKER_CACHE_HOME` to establish isolation of the clip models on disk. If you do not want to rely on a horde specific folder structure, define `TRANSFORMERS_CACHE` to define where you'd prefer the models to be. If neither are defined, the default huggingface folder location for the system used, typically `~/.cache`, depending on other environnement variables, [see the official huggingface docs](https://huggingface.co/docs/transformers/installation#cache-setup) for more info.
+This library is made with the default AI Horde worker in mind, and relies on the environment variable `AIWORKER_CACHE_HOME` to establish isolation of the clip models on disk. If you do not want to rely on a horde specific folder structure, define `HF_HOME` to define where you'd prefer the models to be. If neither are defined, the default huggingface folder location for the system used, typically `~/.cache`, depending on other environnement variables, [see the official huggingface docs](https://huggingface.co/docs/transformers/installation#cache-setup) for more info.
+
+> Warning: If you use `AIWORKER_CACHE_HOME`, other environment variables can and will be overridden, including `HF_HOME` and potentially any other related variables. Using `AIWORKER_CACHE_HOME` is explictly opting into the horde isolation scheme, which may not be suitable for other contexts and may lead to duplicate (and very large) models on disk. If you want to use this library outside of the horde, it is recommended to set `HF_HOME` instead.
 
 ## Installing
 
-Make sure pytorch is installed, preferably with CUDA/ROCM support.
+Make sure pytorch is installed, preferably with CUDA/ROCM or other GPU support.
 
 ```bash
-    pip install horde_safety
+pip install horde_safety
 ```
 
 ## Use

--- a/horde_safety/__init__.py
+++ b/horde_safety/__init__.py
@@ -1,35 +1,68 @@
 """Contains the functionality for client-side safety measures for the AI Horde."""
 
-# flake8: noqa
 import os
+
 from loguru import logger
 
-CACHE_FOLDER_PATH: str = os.path.expanduser("~/.cache/huggingface/")
 
-AIWORKER_CACHE_HOME = os.getenv("AIWORKER_CACHE_HOME")
-TRANSFORMERS_CACHE = os.getenv("TRANSFORMERS_CACHE")
-HF_HOME = os.getenv("HF_HOME")
+def get_cache_folder_path() -> str:
+    """Determine the cache folder path for Hugging Face Transformers.
 
-if AIWORKER_CACHE_HOME:
-    if not TRANSFORMERS_CACHE and not HF_HOME:
-        CACHE_FOLDER_PATH = os.path.join(AIWORKER_CACHE_HOME, "clip_blip")
-        os.environ["HF_HOME"] = os.path.join(AIWORKER_CACHE_HOME, "hf_transformers")
+    Priority:
+    1. HF_HOME
+    2. TRANSFORMERS_CACHE
+    3. Default path
+
+    Returns:
+        str: The path to the appropriate huggingface cache folder.
+    """
+    hf_home = os.getenv("HF_HOME")
+    transformers_cache = os.getenv("TRANSFORMERS_CACHE")
+    default_path = os.path.expanduser("~/.cache/huggingface/")
+    if hf_home:
+        logger.debug(f"Using HF_HOME: {hf_home}")
+        return hf_home
+    elif transformers_cache:
+        logger.debug(f"Using TRANSFORMERS_CACHE: {transformers_cache}")
+        return transformers_cache
     else:
-        logger.info("TRANSFORMERS_CACHE or HF_HOME already set, not overriding")
-else:
-    logger.info("AIWORKER_CACHE_HOME not set, using default huggingface cache paths.")
-    if HF_HOME:
-        CACHE_FOLDER_PATH = HF_HOME
-        logger.debug(f"Using HF_HOME: {HF_HOME}")
-    elif TRANSFORMERS_CACHE:
-        CACHE_FOLDER_PATH = TRANSFORMERS_CACHE
-        logger.debug(f"Using TRANSFORMERS_CACHE: {TRANSFORMERS_CACHE}")
-    else:
-        logger.debug(f"Using default cache path: {CACHE_FOLDER_PATH}")
+        logger.debug(f"Using default cache path: {default_path}")
+        return default_path
 
-from horde_safety.interrogate import get_interrogator_no_blip, CAPTION_MODELS
-from horde_safety.csam_checker import check_for_csam
-from horde_safety.deep_danbooru_model import DeepDanbooruModel, get_deep_danbooru_model
+
+def setup_cache_paths() -> str:
+    """Set up the cache paths for Hugging Face Transformers based on environment variables.
+
+    Returns:
+        str: The path to the cache folder. This may be a horde-specific path if AIWORKER_CACHE_HOME is set.
+            Else, it will use the default Hugging Face cache paths.
+    """
+    aiworker_cache_home = os.getenv("AIWORKER_CACHE_HOME")
+    transformers_cache = os.getenv("TRANSFORMERS_CACHE")
+    hf_home = os.getenv("HF_HOME")
+
+    if aiworker_cache_home and not (transformers_cache or hf_home):
+        cache_folder_path = os.path.join(aiworker_cache_home, "clip_blip")
+        os.environ["HF_HOME"] = os.path.join(aiworker_cache_home, "hf_transformers")
+        logger.debug(f"Set CACHE_FOLDER_PATH to {cache_folder_path} and HF_HOME to {os.environ['HF_HOME']}")
+    else:
+        if aiworker_cache_home:
+            logger.info("TRANSFORMERS_CACHE or HF_HOME already set, not overriding")
+        else:
+            logger.info("AIWORKER_CACHE_HOME not set, using default huggingface cache paths.")
+        cache_folder_path = get_cache_folder_path()
+
+    os.makedirs(cache_folder_path, exist_ok=True)
+    logger.debug(f"Created cache directory: {cache_folder_path}")
+
+    return cache_folder_path
+
+
+CACHE_FOLDER_PATH: str = setup_cache_paths()
+
+from horde_safety.csam_checker import check_for_csam  # noqa: E402
+from horde_safety.deep_danbooru_model import DeepDanbooruModel, get_deep_danbooru_model  # noqa: E402
+from horde_safety.interrogate import CAPTION_MODELS, get_interrogator_no_blip  # noqa: E402
 
 __all__ = [
     "get_interrogator_no_blip",

--- a/horde_safety/deep_danbooru_model.py
+++ b/horde_safety/deep_danbooru_model.py
@@ -39,7 +39,7 @@ def verify_deep_danbooru_model_hash(target_filename: str | Path) -> bool:
     return True
 
 
-default_deep_danbooru_model_path = Path(CACHE_FOLDER_PATH) / model_name
+default_deep_danbooru_model_path: Path = Path(CACHE_FOLDER_PATH) / model_name
 
 
 def download_deep_danbooru_model(target_filename: str | Path = default_deep_danbooru_model_path):


### PR DESCRIPTION
- [refactor: perf tweaks](https://github.com/Haidra-Org/horde-safety/commit/73fe346bec0cf4c580796bf0235c3874d36840e3)
  - Enables batched evaluation of images
  - Other flow-and-control improvements to reduce memory thrashing and minimize cpu cycles
- [feat: compvis safety checker testing](https://github.com/Haidra-Org/horde-safety/commit/7a133bf7e6f2bad397544756951fd89d3f4ae944)
  - Permits using/evaluating the "default" compvis safety checker that is widely referenced in regards to stable diffusion (such as in the huggingface docs)
- [fix: cache path setup and update README instructions](https://github.com/Haidra-Org/horde-safety/commit/ba95f4df6815163ebcdee1ab8b0f0c34702e0b5e) 
  - Fixed the cache folder path logic in __init__.py to work as intended. Previously, having `TRANSFORMERS_CACHE` or `HF_HOME` set led to the wrong path (the default home dir path) being used.

  - Updated the README to clarify horde-specific environment variable
- [feat: underage_subject flag](https://github.com/Haidra-Org/horde-safety/pull/90/commits/496a0f2cad9479fdfbb71f9a71867fec06c534c4)
  - This field logically existed before, implicitly in the code, but wasn't explicitly defined. This change captures this field. 